### PR TITLE
Multiple cursors and separate modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,30 @@ buffers by invoking `helix-normal-mode`:
 (helix-normal-mode 1)
 ```
 
-### Configuration options
+## Configuration
+
+### Multiple cursors (experimental)
+
+Helix Mode does not come with support for multiple cursors
+out-of-the-box. Instead, it provides extensions for the
+[multiple-cursors.el](https://github.com/magnars/multiple-cursors.el)
+package available on NonGNU ELPA. Provided that you have
+[multiple-cursors.el](https://github.com/magnars/multiple-cursors.el)
+installed, you can enable Helix Mode support with
+`helix-multiple-cursors-setup`:
+
+```lisp
+(use-package helix
+  :after multiple-cursors
+  :config
+  (helix-multiple-cursors-setup))
+```
+
+Enabling Helix multiple cursors support adds selection manipulation
+keybindings that spawn multiple cursors
+(e.g. `helix-multiple-cursors-select-regex`).
+
+### jj as escape
 
 Helix Mode supports remapping "jj" as escape for the purpose of
 exiting Insert Mode. Invoke `helix-jj-setup` to activate jj-mode.

--- a/helix-jj.el
+++ b/helix-jj.el
@@ -1,0 +1,86 @@
+;;; helix-jj.el --- Alternative escape sequences  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025  Graham Marlow
+
+;; Author: Graham Marlow
+;; Keywords: convenience
+;; Version: 0.0.1
+;; Package-Requires: ((emacs "29.1"))
+;; URL: https://github.com/mgmarlow/helix-mode
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Alternative escape sequences for exiting to `helix-normal-mode'.
+
+;;; Code:
+
+(defcustom helix-jj-timeout nil
+  "Timeout in seconds for the 'jj' key sequence to exit insert mode.
+
+Defaults to nil, which disables 'jj' exit functionality.  A short value
+like 0.2 is recommended."
+  :group 'helix)
+
+(defvar-local helix-jj--timer nil
+  "Timer for detecting 'jj' key sequence in insert mode.")
+
+;; TODO: eventually support key combinations other than "jj".
+(defun helix-jj--maybe-key-combo-exit ()
+  "When `helix-jj-timeout' is non-nil, allow existing `helix-insert-mode' via 'jj'.
+
+The timeout set by `helix-jj-timeout' determines how long `helix-mode' waits
+before inserting a 'j' character and giving up on existing `helix-insert-mode'."
+  (interactive)
+  (if helix-jj-timeout
+        (if helix-jj--timer
+            (progn
+              (cancel-timer helix-jj--timer)
+              (setq helix-jj--timer nil)
+              (helix-insert-exit))
+          (setq helix-jj--timer
+                (run-with-timer helix-jj-timeout nil
+                                (lambda ()
+                                  (setq helix-jj--timer nil)
+                                  (self-insert-command 1)))))
+    (self-insert-command 1)))
+
+(defun helix-jj--maybe-abort-key-combo-exit ()
+  "Used in a `pre-command-hook' to escape early from a 'jj' sequence.
+
+If a non-j character is typed, immediately escape from a 'jj' sequence
+and remain in `helix-insert-mode'."
+  (when (and helix-jj-timeout
+             (eq this-command 'self-insert-command)
+             (characterp last-command-event)
+             (not (eq last-command-event ?j))
+             helix-jj--timer)
+    (insert "j")
+    (cancel-timer helix-jj--timer)
+    (setq helix-jj--timer nil)))
+
+;;;###autoload
+(defun helix-jj-setup (&optional timeout)
+  "Set up 'jj' as an alternative way to exit `helix-insert-mode'.
+
+TIMEOUT is passed `helix-jj-timeout', defaulting to 0.2.  The timeout
+controls how many seconds `helix-insert-mode' waits for a second j
+keypress to escape to normal mode."
+  (setq helix-jj-timeout (or timeout 0.2))
+  (add-hook 'pre-command-hook #'helix-jj--maybe-abort-key-combo-exit)
+  (define-key helix-insert-state-keymap "j" #'helix-jj--maybe-key-combo-exit))
+
+(provide 'helix-jj)
+;;; helix-jj.el ends here

--- a/helix-multiple-cursors.el
+++ b/helix-multiple-cursors.el
@@ -32,23 +32,34 @@
 
 (defvar helix-multiple-cursors-run-for-all-commands
   '(helix-forward-char
+    helix-forward-word
     helix-backward-char
+    helix-backward-word
     helix-next-line
     helix-previous-line
-    helix-kill-thing-at-point)
+    helix-go-beginning-line
+    helix-go-end-line
+    helix-kill-thing-at-point
+    helix-insert
+    helix-insert-beginning-line
+    helix-insert-after
+    helix-insert-after-end-line)
   "Helix Mode commands that are run for all cursors.")
 
-(defun helix-multiple-cursors-select-all ()
+(defun helix-multiple-cursors-select-regex ()
   "Mark every match of selection within region."
   (interactive)
-  (call-interactively #'mc/mark-all-in-region))
+  (call-interactively #'mc/mark-all-in-region-regexp))
 
 ;;;###autoload
 (defun helix-multiple-cursors-setup ()
   "Set up Helix Mode keybindings for multiple-cursors."
   (dolist (cmd helix-multiple-cursors-run-for-all-commands)
     (add-to-list 'mc/cmds-to-run-for-all cmd))
-  (define-key helix-normal-state-keymap "s" #'helix-multiple-cursors-select-all))
+  (advice-add #'mc/keyboard-quit :before #'helix--clear-data)
+  (define-key helix-normal-state-keymap "s" #'helix-multiple-cursors-select-regex)
+  (define-key helix-normal-state-keymap "," #'mc/keyboard-quit)
+  (define-key helix-normal-state-keymap [escape] #'mc/keyboard-quit))
 
 (provide 'helix-multiple-cursors)
 ;;; helix-multiple-cursors.el ends here

--- a/helix-multiple-cursors.el
+++ b/helix-multiple-cursors.el
@@ -1,0 +1,54 @@
+;;; helix-multiple-cursors.el --- Bridge between helix-mode and multiple-cursors  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025  Graham Marlow
+
+;; Author: Graham Marlow
+;; Keywords: convenience
+;; Version: 0.0.1
+;; Package-Requires: ((emacs "29.1"))
+;; URL: https://github.com/mgmarlow/helix-mode
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Extensions for multiple-cursors:
+;; https://github.com/magnars/multiple-cursors.el/tree/master
+
+;;; Code:
+
+(require 'multiple-cursors nil t)
+
+(defvar helix-multiple-cursors-run-for-all-commands
+  '(helix-forward-char
+    helix-backward-char
+    helix-next-line
+    helix-previous-line
+    helix-kill-thing-at-point)
+  "Helix Mode commands that are run for all cursors.")
+
+(defun helix-multiple-cursors-select-all ()
+  "Mark every match of selection within region."
+  (interactive)
+  (call-interactively #'mc/mark-all-in-region))
+
+;;;###autoload
+(defun helix-multiple-cursors-setup ()
+  "Set up Helix Mode keybindings for multiple-cursors."
+  (dolist (cmd helix-multiple-cursors-run-for-all-commands)
+    (add-to-list 'mc/cmds-to-run-for-all cmd))
+  (define-key helix-normal-state-keymap "s" #'helix-multiple-cursors-select-all))
+
+(provide 'helix-multiple-cursors)
+;;; helix-multiple-cursors.el ends here

--- a/helix-multiple-cursors.el
+++ b/helix-multiple-cursors.el
@@ -54,6 +54,8 @@
 ;;;###autoload
 (defun helix-multiple-cursors-setup ()
   "Set up Helix Mode keybindings for multiple-cursors."
+  (unless (featurep 'multiple-cursors)
+    (error "requires the multiple-cursors package"))
   (dolist (cmd helix-multiple-cursors-run-for-all-commands)
     (add-to-list 'mc/cmds-to-run-for-all cmd))
   (advice-add #'mc/keyboard-quit :before #'helix--clear-data)

--- a/helix.el
+++ b/helix.el
@@ -566,5 +566,8 @@ Argument STATUS is passed through to `helix-mode-maybe-activate'."
      (helix-normal-mode (helix-normal-mode -1))
      (helix-insert-mode (helix-insert-mode -1)))))
 
+;; Extensions
+(require 'helix-multiple-cursors)
+
 (provide 'helix)
 ;;; helix.el ends here

--- a/helix.el
+++ b/helix.el
@@ -31,18 +31,8 @@
   "Custom group for Helix."
   :group 'helix)
 
-(defcustom helix-jj-timeout nil
-  "Timeout in seconds for the 'jj' key sequence to exit insert mode.
-
-Defaults to nil, which disables 'jj' exit functionality.  A short value
-like 0.2 is recommended."
-  :group 'helix)
-
 (defvar-local helix--current-state 'normal
   "Current modal state, one of normal or insert.")
-
-(defvar-local helix--jj-timer nil
-  "Timer for detecting 'jj' key sequence in insert mode.")
 
 (defvar helix-state-mode-alist
   `((insert . helix-insert-mode)
@@ -77,10 +67,7 @@ Nil if no search has taken place while `helix-mode' is active.")
 (defun helix--clear-data ()
   "Clear any intermediate data, e.g. selections/mark."
   (setq helix--current-selection nil)
-  (deactivate-mark)
-  (when helix--jj-timer
-    (cancel-timer helix--jj-timer)
-    (setq helix--jj-timer nil)))
+  (deactivate-mark))
 
 ;; Ensure `keyboard-quit' clears out intermediate Helix state.
 (advice-add #'keyboard-quit :before #'helix--clear-data)
@@ -94,49 +81,6 @@ Nil if no search has taken place while `helix-mode' is active.")
   "Switch to normal state."
   (interactive)
   (helix--switch-state 'normal))
-
-;; TODO: eventually support key combinations other than "jj".
-(defun helix--maybe-key-combo-exit ()
-  "When `helix-jj-timeout' is non-nil, allow existing `helix-insert-mode' via 'jj'.
-
-The timeout set by `helix-jj-timeout' determines how long `helix-mode' waits
-before inserting a 'j' character and giving up on existing `helix-insert-mode'."
-  (interactive)
-  (if helix-jj-timeout
-        (if helix--jj-timer
-            (progn
-              (cancel-timer helix--jj-timer)
-              (setq helix--jj-timer nil)
-              (helix-insert-exit))
-          (setq helix--jj-timer
-                (run-with-timer helix-jj-timeout nil
-                                (lambda ()
-                                  (setq helix--jj-timer nil)
-                                  (self-insert-command 1)))))
-    (self-insert-command 1)))
-
-(defun helix--maybe-abort-key-combo-exit ()
-  "Used in a `pre-command-hook' to escape early from a 'jj' sequence.
-
-If a non-j character is typed, immediately escape from a 'jj' sequence
-and remain in `helix-insert-mode'."
-  (when (and helix-jj-timeout
-             (eq this-command 'self-insert-command)
-             (characterp last-command-event)
-             (not (eq last-command-event ?j))
-             helix--jj-timer)
-    (insert "j")
-    (cancel-timer helix--jj-timer)
-    (setq helix--jj-timer nil)))
-
-(defun helix-jj-setup (&optional timeout)
-  "Set up 'jj' as an alternative way to exit `helix-insert-mode'.
-
-TIMEOUT is passed `helix-jj-timeout', defaulting to 0.2.  The timeout
-controls how many seconds `helix-insert-mode' waits for a second j
-keypress to escape to normal mode."
-  (setq helix-jj-timeout (or timeout 0.2))
-  (add-hook 'pre-command-hook #'helix--maybe-abort-key-combo-exit))
 
 (defun helix--clear-highlights ()
   "Clear any active highlight, unless `helix--current-state' is non-nil."
@@ -499,7 +443,6 @@ If FORCE is non-nil, don't prompt for save when killing Emacs."
 (defvar helix-insert-state-keymap
   (let ((keymap (make-keymap)))
     (define-key keymap [escape] #'helix-insert-exit)
-    (define-key keymap "j" #'helix--maybe-key-combo-exit)
     keymap)
   "Keymap for Helix insert state.")
 
@@ -568,6 +511,7 @@ Argument STATUS is passed through to `helix-mode-maybe-activate'."
 
 ;; Extensions
 (require 'helix-multiple-cursors)
+(require 'helix-jj)
 
 (provide 'helix)
 ;;; helix.el ends here


### PR DESCRIPTION
Adds extensions for the [multiple-cursors package](https://github.com/magnars/multiple-cursors.el/) to help address #1. The multiple-cursors feature is intentionally not required by helix-mode so that this functionality remains opt-in by default. Although multiple-cursors are core to Helix, I haven't tested the implementation thoroughly enough in Emacs to fully commit to it. For now, folks can enable it by installing multiple-cursors separately and calling `helix-multiple-cursors-setup`.

This PR also splits some of the more fringe functionality (e.g. jj support) into separate packages to keep the main file clean.