### PR TITLE
Add some more helix-like motions

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,24 +123,26 @@ Normal mode is the default mode. You can return to it by pressing
 
 ### Movement
 
-| Key | Description                     | Command                     |
-|:----|:--------------------------------|:----------------------------|
-| h   | Move left                       | `helix-backward-char`       |
-| l   | Move right                      | `helix-forward-char`        |
-| j   | Move down                       | `helix-next-line`           |
-| k   | Move up                         | `helix-previous-line`       |
-| w   | Move next word                  | `helix-forward-word`        |
-| W   | Move next WORD                  | `helix-forward-long-word`   |
-| b   | Move previous word              | `helix-backward-word`       |
-| B   | Move previous WORD              | `helix-backward-long-word`  |
-| t   | Find 'till next char            | `helix-find-till-char`      |
-| T   | Find 'till prev char            | `helix-find-prev-till-char` |
-| f   | Find next char                  | `helix-find-next-char`      |
-| F   | Find prev char                  | `helix-find-prev-char`      |
-| M-. | Repeat last motion (f, t, F, T) | `helix-find-repeat`         |
-| G   | Go to line                      | N/A                         |
-| C-b | Move page up                    | N/A                         |
-| C-f | Move page down                  | N/A                         |
+| Key | Description                     | Command                        |
+|:----|:--------------------------------|:-------------------------------|
+| h   | Move left                       | `helix-backward-char`          |
+| l   | Move right                      | `helix-forward-char`           |
+| j   | Move down                       | `helix-next-line`              |
+| k   | Move up                         | `helix-previous-line`          |
+| w   | Move next word start            | `helix-forward-word-start`     |
+| W   | Move next WORD                  | `helix-forward-long-word-start`|
+| e   | Move word end                   | `helix-forward-word-end`       |
+| E   | Move WORD end                   | `helix-forward-long-word-end`  |
+| b   | Move previous word              | `helix-backward-word`          |
+| B   | Move previous WORD              | `helix-backward-long-word`     |
+| t   | Find 'till next char            | `helix-find-till-char`         |
+| T   | Find 'till prev char            | `helix-find-prev-till-char`    |
+| f   | Find next char                  | `helix-find-next-char`         |
+| F   | Find prev char                  | `helix-find-prev-char`         |
+| M-. | Repeat last motion (f, t, F, T) | `helix-find-repeat`            |
+| G   | Go to line                      | N/A                            |
+| C-b | Move page up                    | N/A                            |
+| C-f | Move page down                  | N/A                            |
 
 ### Changes
 

--- a/helix-test.el
+++ b/helix-test.el
@@ -37,13 +37,13 @@
   (with-temp-buffer
     (insert "hello world test")
     (goto-char 1)
-    (helix-forward-long-word)
+    (helix-forward-long-word-start)
     (should (= (point) 6)) ; before "world"
     (should (= (- (region-end) (region-beginning)) 5))
-    (helix-forward-long-word)
+    (helix-forward-long-word-start)
     (should (= (point) 12)) ; before "test"
     (should (= (- (region-end) (region-beginning)) 5))
-    (helix-forward-long-word)
+    (helix-forward-long-word-start)
     (should (= (point) (- (point-max) 1))) ; before end of line
     (should (= (- (region-end) (region-beginning)) 3))))
 
@@ -52,10 +52,10 @@
   (with-temp-buffer
     (insert "this test-string-example works")
     (goto-char 1)
-    (helix-forward-long-word)
+    (helix-forward-long-word-start)
     (should (= (point) 5)) ; before "test-string-example"
     (should (= (- (region-end) (region-beginning)) 4))
-    (helix-forward-long-word)
+    (helix-forward-long-word-start)
     (should (= (point) 25)) ; before "works"
     (should (= (- (region-end) (region-beginning)) 19))))
 
@@ -64,7 +64,7 @@
   (with-temp-buffer
     (insert "word next")
     (goto-char 5) ; on the first whitespace
-    (helix-forward-long-word)
+    (helix-forward-long-word-start)
     (should (= (point) (- (point-max) 1))) ; before end of line
     (should (= (- (region-end) (region-beginning)) 3))))
 
@@ -73,7 +73,7 @@
   (with-temp-buffer
     (insert "word   \t  next")
     (goto-char 5) ; on the first whitespace
-    (helix-forward-long-word)
+    (helix-forward-long-word-start)
     (should (= (point) 10)) ; start of "next"
     (should (= (- (region-end) (region-beginning)) 5))))
 
@@ -82,13 +82,13 @@
   (with-temp-buffer
     (insert "first line\nsecond line\nthird")
     (goto-char 1) ; start of buffer
-    (helix-forward-long-word)
+    (helix-forward-long-word-start)
     (should (= (point) 6)) ; before "line"
     (should (= (- (region-end) (region-beginning)) 5))
-    (helix-forward-long-word)
+    (helix-forward-long-word-start)
     (should (= (point) 10)) ; before end of first line
     (should (= (- (region-end) (region-beginning)) 3))
-    (helix-forward-long-word)
+    (helix-forward-long-word-start)
     (should (= (point) 18)) ; before "line" of second line
     (should (= (- (region-end) (region-beginning)) 6))))
 
@@ -97,7 +97,7 @@
   (with-temp-buffer
     (insert "first\n\n\nsecond")
     (goto-char 5) ; before end of first line
-    (helix-forward-long-word)
+    (helix-forward-long-word-start)
     (should (= (point) (- (point-max) 1))) ; before end of second line
     (should (= (- (region-end) (region-beginning)) 5))))
 
@@ -107,7 +107,7 @@
     (insert "test word")
     (goto-char (point-max))
     (let ((initial-point (point)))
-      (helix-forward-long-word)
+      (helix-forward-long-word-start)
       (should (= (point) initial-point))
       (should (not (use-region-p))))))
 
@@ -116,7 +116,7 @@
   (with-temp-buffer
     (insert "word1_part2-part3.part4 next")
     (goto-char 1)
-    (helix-forward-long-word)
+    (helix-forward-long-word-start)
     (should (= (point) 24)) ; before "next"
     (should (= (- (region-end) (region-beginning)) 23))))
 
@@ -125,10 +125,10 @@
   (with-temp-buffer
     (insert "Hello, world! How are you?")
     (goto-char 1)
-    (helix-forward-long-word)
+    (helix-forward-long-word-start)
     (should (= (point) 7)) ; before "world!"
     (should (= (- (region-end) (region-beginning)) 6))
-    (helix-forward-long-word)
+    (helix-forward-long-word-start)
     (should (= (point) 14)) ; before "How"
     (should (= (- (region-end) (region-beginning)) 6))))
 
@@ -245,7 +245,7 @@
   "Test forward movement in empty buffer."
   (with-temp-buffer
     (let ((initial-point (point)))
-      (helix-forward-long-word)
+      (helix-forward-long-word-start)
       (should (= (point) initial-point))
       (should (not (use-region-p))))))
 
@@ -262,7 +262,7 @@
   (with-temp-buffer
     (insert "   \t\n  ")
     (goto-char 1)
-    (helix-forward-long-word)
+    (helix-forward-long-word-start)
     (should (= (point) 4)) ; before end of first line
     (should (= (- (region-end) (region-beginning)) 3))))
 
@@ -280,10 +280,10 @@
   (with-temp-buffer
     (insert "a b c d")
     (goto-char 1)
-    (helix-forward-long-word)
+    (helix-forward-long-word-start)
     (should (= (point) 2)) ; before "b"
     (should (= (- (region-end) (region-beginning)) 1))
-    (helix-forward-long-word)
+    (helix-forward-long-word-start)
     (should (= (point) 4)) ; before "c"
     (should (= (- (region-end) (region-beginning)) 1))))
 


### PR DESCRIPTION
As mentioned in #16 some of the keybinds are missing or behave in a slightly unexpected way (when coming directly from helix.)

Here are the changes i've done:
1. More precise naming for the "*-forward-word*" commands. I also added new ones.
2. I added an additional "*-select-line-up" command, which is by default not bound, but can be. It's also unbound in normal helix.
  - However, i noticed that with the current implementation, the regions won't be maintained if you do e.g. this: select down, select up -> it will be a bit odd.
3. I added `helix-change-thing-at-point`, which is similar to the `c` command in default helix.
4. I also changed the behaviour of the visual mode, that it also selects the character that is *under* the cursor.

I am not sure how to test it, i generally used a local version in which i have overriden the keybinds. 
The visual-mode change is untested (sadly), but i am unsure how i can actually test it. So some guidance there would be nice :)