### PR TITLE
Add note about ESC in terminal mode to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ keybindings that spawn multiple cursors
 Helix Mode supports remapping "jj" as escape for the purpose of
 exiting Insert Mode. Invoke `helix-jj-setup` to activate jj-mode.
 
+This is useful in terminal mode, since escape [currently cannot be
+bound](https://github.com/mgmarlow/helix-mode/issues/24).
+
 ```lisp
 (helix-jj-setup 0.2)
 ```


### PR DESCRIPTION
Currently helix-mode does not bind the escape key in terminal mode (#24).

Add a note to the README suggesting use of `jj` as a workaround.

I assume this is part of why this feature exists, but it might save users' time to see it called out explicitly. I spent a bit of time doing research and wondering whether escape was meant to work before concluding otherwise.