### PR TITLE
Add "Add cursor below" keybinding on C

### DIFF
--- a/helix-multiple-cursors.el
+++ b/helix-multiple-cursors.el
@@ -65,6 +65,7 @@
     (add-to-list 'mc/cmds-to-run-for-all cmd))
   (advice-add #'mc/keyboard-quit :before #'helix--clear-data)
   (helix-define-key 'normal "s" #'helix-multiple-cursors-select-regex)
+  (helix-define-key 'normal "C" #'mc/mark-next-like-this)
   (helix-define-key 'normal "," #'mc/keyboard-quit)
   (helix-define-key 'normal [escape] #'mc/keyboard-quit))
 


### PR DESCRIPTION
It should be noted that this behaves a bit differently to helix:
- if nothing is currently selected it adds a cursor on the line below at the same character offset if possible, otherwise at the end of the line
  - in the absence of lines shorter than the first this behaves the same as helix
  - helix would skip shorter lines instead, and keep the offset
- if something is selected, then it actually adds a cursor and selection for the next occurrence of the selection, unlike helix

This is close enough to satisfy my needs, while being arguably more useful with the behavior when something is selected.

Fixes #29.