### PR TITLE
Tree-sitter extensions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 EMACS ?= emacs
 
-FILES = helix-core.el helix-avy.el helix-multiple-cursors.el helix-jj.el helix.el
+FILES = helix-core.el helix-treesit.el helix-avy.el helix-multiple-cursors.el helix-jj.el helix.el
 
 DEPS = package-lint
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ Example:
 Normal mode is the default mode. You can return to it by pressing
 `ESC`.
 
+Note: tree-sitter commands (TS) require an active tree-sitter parser in
+the current buffer
+
 ### Movement
 
 | Key | Description                     | Command                        |
@@ -165,6 +168,8 @@ Normal mode is the default mode. You can return to it by pressing
 | E   | Move WORD end                   | `helix-forward-long-word-end`  |
 | b   | Move previous word              | `helix-backward-word`          |
 | B   | Move previous WORD              | `helix-backward-long-word`     |
+| M-b | Move to parent syntax node start (TS) | `helix-treesit-go-parent-start` |
+| M-e | Move to parent syntax node end (TS) | `helix-treesit-go-parent-end`   |
 | t   | Find 'till next char            | `helix-find-till-char`         |
 | T   | Find 'till prev char            | `helix-find-prev-till-char`    |
 | f   | Find next char                  | `helix-find-next-char`         |
@@ -195,9 +200,11 @@ Normal mode is the default mode. You can return to it by pressing
 
 ### Selection
 
-| Key | Description         | Command             |
-|:----|:--------------------|:--------------------|
-| x   | Select current line | `helix-select-line` |
+| Key | Description                                | Command                  |
+|:----|:-------------------------------------------|:-------------------------|
+| x   | Select current line                        | `helix-select-line`      |
+| M-i | Shrink syntax tree object selection (TS)   | `helix-shrink-selection` |
+| M-o | Expand syntax tree object selection (TS)   | `helix-expand-selection` |
 
 ### Search
 

--- a/helix-multiple-cursors.el
+++ b/helix-multiple-cursors.el
@@ -33,6 +33,7 @@
 (defvar mc/cmds-to-run-for-all)
 (declare-function mc/keyboard-quit "multiple-cursors")
 (declare-function mc/mark-all-in-region-regexp "multiple-cursors")
+(declare-function mc/mark-next-like-this "multiple-cursors")
 
 (defvar helix-multiple-cursors-run-for-all-commands
   '(helix-forward-char

--- a/helix-test.el
+++ b/helix-test.el
@@ -27,8 +27,107 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (require 'ert)
 (require 'helix)
+
+(cl-defstruct helix-test--treesit-node
+  start
+  end
+  parent
+  (named t))
+
+(cl-defun helix-test--treesit-node (start end &key parent (named t))
+  "Return a fake tree-sitter node from START to END."
+  (make-helix-test--treesit-node
+   :start start :end end :parent parent :named named))
+
+(defun helix-test--should-region (start end &optional point)
+  "Assert the active region spans START to END.
+
+When POINT is non-nil, also assert point is there."
+  (should (= (region-beginning) start))
+  (should (= (region-end) end))
+  (when point
+    (should (= (point) point))))
+
+(defmacro helix-test--with-mocked-treesit-node (node &rest body)
+  "Run BODY with tree-sitter node functions mocked around NODE."
+  (declare (indent 1))
+  `(cl-letf (((symbol-function 'treesit-node-at)
+              (lambda (&rest _args) ,node))
+             ((symbol-function 'treesit-parser-list)
+              (lambda (&rest _args) '(helix-test-parser)))
+             ((symbol-function 'treesit-buffer-root-node)
+              (lambda (&rest _args) ,node))
+             ((symbol-function 'treesit-node-descendant-for-range)
+              (lambda (&rest _args) ,node))
+             ((symbol-function 'treesit-parent-until)
+              (lambda (node pred &optional include-node)
+                (unless include-node
+                  (setq node (helix-test--treesit-node-parent node)))
+                (while (and node (not (funcall pred node)))
+                  (setq node (helix-test--treesit-node-parent node)))
+                node))
+             ((symbol-function 'treesit-node-enclosed-p)
+              (lambda (smaller larger &optional strict)
+                (let ((small-start (if (consp smaller)
+                                       (car smaller)
+                                     (helix-test--treesit-node-start smaller)))
+                      (small-end (if (consp smaller)
+                                     (cdr smaller)
+                                   (helix-test--treesit-node-end smaller)))
+                      (large-start (if (consp larger)
+                                       (car larger)
+                                     (helix-test--treesit-node-start larger)))
+                      (large-end (if (consp larger)
+                                     (cdr larger)
+                                   (helix-test--treesit-node-end larger))))
+                  (and (<= large-start small-start)
+                       (>= large-end small-end)
+                       (or (not strict)
+                           (< large-start small-start)
+                           (> large-end small-end))))))
+             ((symbol-function 'treesit-node-start)
+              #'helix-test--treesit-node-start)
+             ((symbol-function 'treesit-node-end)
+              #'helix-test--treesit-node-end)
+             ((symbol-function 'treesit-node-parent)
+              #'helix-test--treesit-node-parent)
+             ((symbol-function 'treesit-node-check)
+              (lambda (node property)
+                (and node
+                     (eq property 'named)
+                     (helix-test--treesit-node-named node)))))
+     ,@body))
+
+(defmacro helix-test--with-standard-treesit-buffer (&rest body)
+  "Run BODY in a buffer with a standard mocked tree-sitter node."
+  (declare (indent 0))
+  `(with-temp-buffer
+     (insert "(foo bar)")
+     (goto-char 3)
+     (let* ((root (helix-test--treesit-node 1 10))
+            (symbol (helix-test--treesit-node 2 5 :parent root)))
+       (helix-test--with-mocked-treesit-node symbol
+         ,@body))))
+
+(defmacro helix-test--with-no-treesit-parser (&rest body)
+  "Run BODY in a buffer without a mocked tree-sitter parser."
+  (declare (indent 0))
+  `(with-temp-buffer
+     (insert "(foo bar)")
+     (goto-char 3)
+     (let (message-text)
+       (cl-letf (((symbol-function 'treesit-parser-list)
+                  (lambda (&rest _args) nil))
+                 ((symbol-function 'treesit-node-at)
+                  (lambda (&rest _args)
+                    (error "treesit-node-at should not be called")))
+                 ((symbol-function 'message)
+                  (lambda (format-string &rest args)
+                    (setq message-text (apply #'format format-string args)))))
+         ,@body))))
 
 ;;; Forward long word tests
 
@@ -447,6 +546,181 @@
     (helix-backward-long-word)
     (should (= (point) 5)) ; start of "c"
     (should (= (- (region-end) (region-beginning)) 2))))
+
+;;; Tree-sitter selection tests
+
+(ert-deftest helix-test-treesit-parser-list-supports-emacs-29-arity ()
+  "Test parser detection supports Emacs 29 style `treesit-parser-list'."
+  (cl-letf (((symbol-function 'treesit-parser-list)
+             (lambda (&rest args)
+               (if args
+                   (signal 'wrong-number-of-arguments
+                           (list 'treesit-parser-list (length args)))
+                 '(helix-test-parser)))))
+    (should (equal (helix-treesit--parser-list) '(helix-test-parser)))))
+
+(ert-deftest helix-test-treesit-node-enclosed-fallback ()
+  "Test node containment works without `treesit-node-enclosed-p'."
+  (let ((node (helix-test--treesit-node 1 10))
+        (original-fboundp (symbol-function 'fboundp)))
+    (cl-letf (((symbol-function 'treesit-node-start)
+               #'helix-test--treesit-node-start)
+              ((symbol-function 'treesit-node-end)
+               #'helix-test--treesit-node-end)
+              ((symbol-function 'fboundp)
+               (lambda (symbol)
+                 (and (not (eq symbol 'treesit-node-enclosed-p))
+                      (funcall original-fboundp symbol)))))
+      (should (helix-treesit--node-enclosed-p (cons 2 5) node 'partial))
+      (should-not (helix-treesit--node-enclosed-p (cons 1 10) node 'partial))
+      (should (helix-treesit--node-enclosed-p (cons 2 5) node t))
+      (should-not (helix-treesit--node-enclosed-p (cons 1 5) node t)))))
+
+(ert-deftest helix-test-treesit-node-enclosed-supports-emacs-29-signature ()
+  "Test node containment falls back with Emacs 29 `treesit-node-enclosed-p'."
+  (let ((node (helix-test--treesit-node 1 10)))
+    (cl-letf (((symbol-function 'treesit-node-start)
+               #'helix-test--treesit-node-start)
+              ((symbol-function 'treesit-node-end)
+               #'helix-test--treesit-node-end)
+              ((symbol-function 'treesit-node-enclosed-p)
+               (lambda (node start end)
+                 (unless (helix-test--treesit-node-p node)
+                   (signal 'wrong-type-argument
+                           (list 'treesit-node-p node)))
+                 (and (<= (helix-test--treesit-node-start node) start)
+                      (>= (helix-test--treesit-node-end node) end)))))
+      (should (helix-treesit--node-enclosed-p (cons 2 5) node 'partial))
+      (should-not (helix-treesit--node-enclosed-p (cons 1 10) node 'partial)))))
+
+(ert-deftest helix-test-expand-selection-selects-node-at-point ()
+  "Test expanding selection selects the smallest named node at point."
+  (helix-test--with-standard-treesit-buffer
+    (helix-expand-selection)
+    (should mark-active)
+    (helix-test--should-region 2 5 5)))
+
+(ert-deftest helix-test-expand-selection-expands-active-region ()
+  "Test expanding an active node selection selects the parent node."
+  (helix-test--with-standard-treesit-buffer
+    (helix-expand-selection)
+    (helix-expand-selection)
+    (helix-test--should-region 1 10 10)))
+
+(ert-deftest helix-test-expand-selection-skips-unnamed-ancestors ()
+  "Test expanding selection skips unnamed tree-sitter ancestors."
+  (with-temp-buffer
+    (insert "(foo bar)")
+    (goto-char 3)
+    (let* ((root (helix-test--treesit-node 1 10))
+           (list-node (helix-test--treesit-node 1 10
+                                                :parent root :named nil))
+           (symbol (helix-test--treesit-node 2 5 :parent list-node)))
+      (helix-test--with-mocked-treesit-node symbol
+        (helix-expand-selection)
+        (helix-expand-selection)
+        (helix-test--should-region 1 10 10)))))
+
+(ert-deftest helix-test-expand-selection-preserves-largest-node ()
+  "Test expanding the largest available node leaves selection unchanged."
+  (with-temp-buffer
+    (insert "(foo bar)")
+    (let ((root (helix-test--treesit-node 1 10)))
+      (helix--select-region 1 10)
+      (helix-test--with-mocked-treesit-node root
+        (helix-expand-selection)
+        (helix-test--should-region 1 10 10)))))
+
+(ert-deftest helix-test-expand-selection-without-parser-does-not-error ()
+  "Test expanding selection without a tree-sitter parser does not error."
+  (helix-test--with-no-treesit-parser
+    (helix-expand-selection)
+    (should (= (point) 3))
+    (should-not mark-active)
+    (should (equal message-text "Not in a tree-sitter buffer"))))
+
+(ert-deftest helix-test-shrink-selection-restores-previous-expansion ()
+  "Test shrinking selection restores the previous tree-sitter selection."
+  (helix-test--with-standard-treesit-buffer
+    (helix-expand-selection)
+    (helix-expand-selection)
+    (helix-shrink-selection)
+    (helix-test--should-region 2 5 5)))
+
+(ert-deftest helix-test-shrink-selection-selects-node-without-history ()
+  "Test shrinking without history selects the current tree-sitter node."
+  (helix-test--with-standard-treesit-buffer
+    (helix-shrink-selection)
+    (helix-test--should-region 2 5 5)))
+
+(ert-deftest helix-test-shrink-selection-stops-at-smallest-expansion ()
+  "Test shrinking twice does not duplicate the smallest tree-sitter selection."
+  (helix-test--with-standard-treesit-buffer
+    (helix-expand-selection)
+    (helix-expand-selection)
+    (helix-shrink-selection)
+    (helix-shrink-selection)
+    (helix-test--should-region 2 5 5)))
+
+(ert-deftest helix-test-shrink-selection-without-parser-preserves-selection ()
+  "Test shrinking without a tree-sitter parser does not move point."
+  (helix-test--with-no-treesit-parser
+    (helix--select-region 2 5)
+    (helix-shrink-selection)
+    (helix-test--should-region 2 5 5)
+    (should (equal message-text "Not in a tree-sitter buffer"))))
+
+(ert-deftest helix-test-treesit-go-parent-start ()
+  "Test moving to the parent tree-sitter node start."
+  (helix-test--with-standard-treesit-buffer
+    (helix-treesit-go-parent-start)
+    (should (= (point) 1))))
+
+(ert-deftest helix-test-treesit-go-parent-end-from-selection ()
+  "Test moving to the parent tree-sitter node end from a selection."
+  (helix-test--with-standard-treesit-buffer
+    (helix--select-region 2 5)
+    (helix-treesit-go-parent-end)
+    (should (= (point) 10))))
+
+(ert-deftest helix-test-treesit-go-parent-skips-unnamed-parents ()
+  "Test moving to a parent tree-sitter node skips unnamed parents."
+  (with-temp-buffer
+    (insert "(foo bar)")
+    (goto-char 3)
+    (let* ((root (helix-test--treesit-node 1 10))
+           (unnamed (helix-test--treesit-node 2 5
+                                              :parent root :named nil))
+           (symbol (helix-test--treesit-node 3 4 :parent unnamed)))
+      (helix-test--with-mocked-treesit-node symbol
+        (helix-treesit-go-parent-start)
+        (should (= (point) 1))))))
+
+(ert-deftest helix-test-treesit-go-parent-without-parser-does-not-error ()
+  "Test moving to parent node without a tree-sitter parser does not error."
+  (helix-test--with-no-treesit-parser
+    (helix-treesit-go-parent-start)
+    (should (= (point) 3))
+    (should-not mark-active)
+    (should (equal message-text "Not in a tree-sitter buffer"))))
+
+(ert-deftest helix-test-treesit-setup-binds-selection-commands ()
+  "Test tree-sitter setup binds tree-sitter commands in normal mode."
+  (let ((original-m-i (lookup-key helix-normal-state-keymap (kbd "M-i")))
+        (original-m-b (lookup-key helix-normal-state-keymap (kbd "M-b")))
+        (original-m-e (lookup-key helix-normal-state-keymap (kbd "M-e"))))
+    (unwind-protect
+        (progn
+          (helix-treesit-setup)
+          (should (eq (lookup-key helix-normal-state-keymap (kbd "M-i"))
+                      #'helix-shrink-selection))
+          (should (eq (lookup-key helix-normal-state-keymap (kbd "M-b"))
+                      #'helix-treesit-go-parent-start))
+          (should (eq (lookup-key helix-normal-state-keymap (kbd "M-e"))
+                      #'helix-treesit-go-parent-end)))
+      (define-key helix-normal-state-keymap (kbd "M-i") original-m-i)
+      (define-key helix-normal-state-keymap (kbd "M-b") original-m-b)
+      (define-key helix-normal-state-keymap (kbd "M-e") original-m-e))))
 
 ;; Find char
 

--- a/helix-treesit.el
+++ b/helix-treesit.el
@@ -1,0 +1,226 @@
+;;; helix-treesit.el --- Tree-sitter extensions for helix-mode  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026  Graham Marlow
+
+;; Author: Graham Marlow
+;; Keywords: convenience
+;; URL: https://github.com/mgmarlow/helix-mode
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Tree-sitter extensions.
+
+;;; Code:
+
+(require 'helix-core)
+(require 'treesit)
+
+(defvar-local helix-treesit--selection-stack nil
+  "Stack of tree-sitter selection bounds.
+
+The car is the current tree-sitter selection, and the cdr is the
+shrink history.")
+
+(defun helix-treesit--clear-selection-state ()
+  "Clear tree-sitter selection stack for the current buffer."
+  (setq helix-treesit--selection-stack nil))
+
+(defun helix-treesit--active-region-bounds ()
+  "Return active region bounds as a cons cell, or nil."
+  (when (and mark-active (mark t) (/= (point) (mark t)))
+    (cons (region-beginning) (region-end))))
+
+(defun helix-treesit--select-node-bounds (bounds)
+  "Select BOUNDS."
+  (helix--select-region (car bounds) (cdr bounds)))
+
+(defun helix-treesit--node-bounds (node)
+  "Return NODE bounds as a cons cell."
+  (when node
+    (cons (treesit-node-start node) (treesit-node-end node))))
+
+(defun helix-treesit--node-or-bounds (node-or-bounds)
+  "Return NODE-OR-BOUNDS as a bounds cons cell."
+  (if (consp node-or-bounds)
+      node-or-bounds
+    (helix-treesit--node-bounds node-or-bounds)))
+
+(defun helix-treesit--node-enclosed-fallback-p (smaller larger &optional strict)
+  "Return non-nil when SMALLER bounds are enclosed by LARGER bounds.
+
+SMALLER and LARGER can be either tree-sitter nodes or cons-cell
+bounds.  Argument STRICT follows the same meaning as in
+`treesit-node-enclosed-p'."
+  (let ((smaller-bounds (helix-treesit--node-or-bounds smaller))
+        (larger-bounds (helix-treesit--node-or-bounds larger)))
+    (and smaller-bounds
+         larger-bounds
+         (<= (car larger-bounds) (car smaller-bounds))
+         (>= (cdr larger-bounds) (cdr smaller-bounds))
+         (or (not strict)
+             (if (eq strict 'partial)
+                 (or (< (car larger-bounds) (car smaller-bounds))
+                     (> (cdr larger-bounds) (cdr smaller-bounds)))
+               (and (< (car larger-bounds) (car smaller-bounds))
+                    (> (cdr larger-bounds) (cdr smaller-bounds))))))))
+
+;; For Emacs 29 compatibility
+(defun helix-treesit--node-enclosed-p (smaller larger &optional strict)
+  "Compatibility wrapper for `treesit-node-enclosed-p'."
+  (if (fboundp 'treesit-node-enclosed-p)
+      (condition-case nil
+          (treesit-node-enclosed-p smaller larger strict)
+        ((wrong-number-of-arguments wrong-type-argument)
+         (helix-treesit--node-enclosed-fallback-p smaller larger strict)))
+    (helix-treesit--node-enclosed-fallback-p smaller larger strict)))
+
+(defun helix-treesit--node-strictly-contains-region-p (node start end)
+  "Return non-nil if NODE strictly contains the region from START to END."
+  (and node
+       (treesit-node-check node 'named)
+       (helix-treesit--node-enclosed-p (cons start end) node 'partial)))
+
+;; Emacs 30 added optional BUFFER/LANGUAGE/TAG arguments.
+(defun helix-treesit--parser-list ()
+  "Return tree-sitter parsers in the current buffer."
+  (condition-case nil
+      (treesit-parser-list nil nil t)
+    (wrong-number-of-arguments
+     (treesit-parser-list))))
+
+(defun helix-treesit--expansion-node (node start end)
+  "Return the nearest named NODE ancestor expanding START to END."
+  (treesit-parent-until
+   node
+   (lambda (candidate)
+     (helix-treesit--node-strictly-contains-region-p candidate start end))
+   t))
+
+(defun helix-treesit--node-at-point ()
+  "Return the named tree-sitter node at point, or nil."
+  (when (helix-treesit--parser-list)
+    (treesit-node-at (point) nil t)))
+
+(defun helix-treesit--node-at-selection-or-point ()
+  "Return the named tree-sitter node at the active selection or point."
+  (when (helix-treesit--parser-list)
+    (let ((bounds (helix-treesit--active-region-bounds)))
+      (if bounds
+          (treesit-node-descendant-for-range
+           (treesit-buffer-root-node) (car bounds) (cdr bounds) t)
+        (treesit-node-at (point) nil t)))))
+
+(defun helix-treesit--named-parent (node)
+  "Return the nearest named parent of NODE."
+  (and node
+       (treesit-parent-until
+        node
+        (lambda (candidate)
+          (treesit-node-check candidate 'named)))))
+
+(defun helix-treesit--go-parent-boundary (boundary)
+  "Move point to BOUNDARY of the parent tree-sitter node."
+  (let ((parent (helix-treesit--named-parent
+                 (helix-treesit--node-at-selection-or-point))))
+    (if parent
+        (progn
+          (helix-treesit--clear-selection-state)
+          (helix--clear-highlights)
+          (goto-char (funcall boundary parent)))
+      (message "No parent tree-sitter node"))))
+
+;;;###autoload
+(defun helix-expand-selection ()
+  "Expand selection to the next enclosing named tree-sitter node.
+
+If no region is active, select the smallest named node containing
+point.  Repeated invocations select increasingly larger ancestor
+nodes."
+  (interactive)
+  (if (helix-treesit--parser-list)
+      (let* ((bounds (helix-treesit--active-region-bounds))
+             (start (or (car bounds) (point)))
+             (end (or (cdr bounds) (point)))
+             (node (helix-treesit--node-at-point))
+             (target (helix-treesit--expansion-node node start end))
+             (target-bounds (helix-treesit--node-bounds target)))
+        (if target
+            (progn
+              (cond
+               ((not bounds)
+                (helix-treesit--clear-selection-state))
+               ((not (equal bounds (car helix-treesit--selection-stack)))
+                (setq helix-treesit--selection-stack (list bounds))))
+              (unless (equal (car helix-treesit--selection-stack)
+                             target-bounds)
+                (push target-bounds helix-treesit--selection-stack))
+              (helix-treesit--select-node-bounds target-bounds))
+          (message "No larger tree-sitter node")))
+    (message "Not in a tree-sitter buffer")))
+
+;;;###autoload
+(defun helix-shrink-selection ()
+  "Shrink selection to the previous tree-sitter selection.
+
+This reverses prior `helix-expand-selection' invocations in the
+current buffer.  If no tree-sitter selection history exists,
+select the current named node."
+  (interactive)
+  (if (helix-treesit--parser-list)
+      (let* ((bounds (helix-treesit--active-region-bounds))
+             (node-bounds (helix-treesit--node-bounds
+                           (helix-treesit--node-at-selection-or-point))))
+        (cond
+         ((and bounds
+               (equal bounds (car helix-treesit--selection-stack))
+               (cdr helix-treesit--selection-stack))
+          (pop helix-treesit--selection-stack)
+          (helix-treesit--select-node-bounds
+           (car helix-treesit--selection-stack)))
+         (node-bounds
+          (setq helix-treesit--selection-stack (list node-bounds))
+          (helix-treesit--select-node-bounds node-bounds))
+         (t
+          (helix-treesit--clear-selection-state)
+          (message "No smaller tree-sitter node"))))
+    (message "Not in a tree-sitter buffer")))
+
+;;;###autoload
+(defun helix-treesit-go-parent-start ()
+  "Move to the start of the parent node in the syntax tree."
+  (interactive)
+  (if (helix-treesit--parser-list)
+      (helix-treesit--go-parent-boundary #'treesit-node-start)
+    (message "Not in a tree-sitter buffer")))
+
+;;;###autoload
+(defun helix-treesit-go-parent-end ()
+  "Move to the end of the parent node in the syntax tree."
+  (interactive)
+  (if (helix-treesit--parser-list)
+      (helix-treesit--go-parent-boundary #'treesit-node-end)
+    (message "Not in a tree-sitter buffer")))
+
+;;;###autoload
+(defun helix-treesit-setup ()
+  "Set up Helix Mode keybindings for tree-sitter."
+  (helix-define-key 'normal (kbd "M-o") #'helix-expand-selection)
+  (helix-define-key 'normal (kbd "M-i") #'helix-shrink-selection)
+  (helix-define-key 'normal (kbd "M-b") #'helix-treesit-go-parent-start)
+  (helix-define-key 'normal (kbd "M-e") #'helix-treesit-go-parent-end))
+
+(provide 'helix-treesit)
+;;; helix-treesit.el ends here

--- a/helix.el
+++ b/helix.el
@@ -71,6 +71,14 @@
 ;;; Code:
 
 (require 'helix-core)
+
+(declare-function helix-avy-setup "helix-avy")
+(declare-function helix-multiple-cursors-setup "helix-multiple-cursors")
+(declare-function helix-treesit-setup "helix-treesit")
+
+(when (locate-library "treesit")
+  (require 'helix-treesit)
+  (helix-treesit-setup))
 (when (locate-library "multiple-cursors")
   (require 'helix-multiple-cursors)
   (helix-multiple-cursors-setup))


### PR DESCRIPTION
Add tree-sitter support based on the built-in `treesit` library. Closes #46 